### PR TITLE
docs: add architecture diagram to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@ Deploy CodiMD on railway
 * CodiMD settings as environment variables
 * Railway config as code via `railway.toml`
 
+## 🏗️ Architecture
+
+```mermaid
+flowchart LR
+    Client(["🌐 Client"]) -->|HTTPS| Domain["Railway Public Domain"]
+    Domain -->|"$PORT"| App["Container\nhackmdio/hackmd"]
+    App --> Volume[("Volume\n/home/hackmd/app/public/uploads")]
+    App -.->|"CMD_DB_URL"| DB[("Separate Railway service\nPostgreSQL (you add)")]
+```
+
 ## Production recommendations (Railway)
 
 * Keep secrets in Railway Variables, never commit them to `.env`


### PR DESCRIPTION
## Summary
- Adds a Mermaid diagram to the README showing this template's deployed architecture: Railway public domain → container (hackmdio/hackmd) → persistent volume for uploads, plus the separate managed Postgres service the docs already say you need to add via `CMD_DB_URL`.
- No functional changes.

## Test plan
- [x] Verified the Mermaid block renders (fenced ```mermaid, GitHub-native rendering).


---
_Generated by [Claude Code](https://claude.ai/code/session_01WwCVWpdDxXTCW5fYFbyCRw)_